### PR TITLE
Initial investigation into supporting virtual templates

### DIFF
--- a/src/EleventyFiles.js
+++ b/src/EleventyFiles.js
@@ -390,7 +390,13 @@ class EleventyFiles {
 
     // Note 2.0.0-canary.19 removed a `filter` option for custom template syntax here that was unpublished and unused.
 
+    // Add any user-configured virtual templates to the collection
+    if (this.config.virtualTemplates) {
+      paths.push(...Object.keys(this.config.virtualTemplates));
+    }
+
     this.pathCache = paths;
+
     return paths;
   }
 

--- a/src/Template.js
+++ b/src/Template.js
@@ -83,6 +83,10 @@ class Template extends TemplateContent {
     this.behavior.setOutputFormat(this.outputFormat);
 
     this.serverlessUrls = null;
+
+    if (this.config.virtualTemplates[this.inputPath]) {
+      this.inputContent = this.config.virtualTemplates[this.inputPath];
+    }
   }
 
   get logger() {
@@ -928,6 +932,12 @@ class Template extends TemplateContent {
   }
 
   async _getDateInstance(key = "birthtimeMs") {
+    // If this path points at a virtual template return the current date as we can't
+    // retreive one from the filesystem.
+    if (Object.keys(this.config.virtualTemplates).includes(this.inputPath)) {
+      return new Date();
+    }
+
     let stat = await this.getInputFileStat();
 
     // Issue 1823: https://github.com/11ty/eleventy/issues/1823

--- a/src/UserConfig.js
+++ b/src/UserConfig.js
@@ -100,6 +100,7 @@ class UserConfig {
     this.libraryAmendments = {};
     this.serverPassthroughCopyBehavior = "passthrough";
     this.urlTransforms = [];
+    this.virtualTemplates = {};
   }
 
   versionCheck(expected) {
@@ -887,6 +888,10 @@ class UserConfig {
     this.urlTransforms.push(callback);
   }
 
+  addVirtualTemplate(path, content) {
+    this.virtualTemplates[path] = content;
+  }
+
   getMergingConfigObject() {
     return {
       templateFormats: this.templateFormats,
@@ -944,6 +949,7 @@ class UserConfig {
       libraryAmendments: this.libraryAmendments,
       serverPassthroughCopyBehavior: this.serverPassthroughCopyBehavior,
       urlTransforms: this.urlTransforms,
+      virtualTemplates: this.virtualTemplates,
     };
   }
 }


### PR DESCRIPTION
This is investigation work into adding virtual templates to eleventy through config.

This prototype adds a new `virtualTemplates` property to `UserConfig` and exposes a `addVirtualTemplate` method, which is used to populate the property.

`eleventyConfig.addVirtualTemplate()` accepts two arguments. The first is a string containing virtual file path of the template, and the second is a string containing the template content. Here's an example:

```js
module.exports = function(eleventyConfig) {
  eleventyConfig.addVirtualTemplate('test.md', '# Hello world!');
}
```

The `EleventyFiles` class uses the configuration to expose the virtual paths as part of the resolved file list. The `Template` classes use the configuration to detect virtual file paths and serve the template content. Everything else should work as usual.